### PR TITLE
This fixes the Serial.print commands in the loop block of PCSynch.ino

### DIFF
--- a/examples/PCsync/PCsync.ino
+++ b/examples/PCsync/PCsync.ino
@@ -120,7 +120,7 @@ void loop()
   DateTime now = rtc.now(); //get the current date-time
   uint32_t ts = now.getEpoch();
   Serial.print("Current RTC Date/Time: ");
-  Serial.print(weekDay[now.dayOfWeek()-1]);
+  Serial.print(weekDay[now.dayOfWeek()]);
   Serial.print(", ");
   Serial.print(charMonth[now.month()-1]);
   Serial.print(' ');

--- a/examples/PCsync/PCsync.ino
+++ b/examples/PCsync/PCsync.ino
@@ -123,17 +123,17 @@ void loop()
   Serial.print(weekDay[now.dayOfWeek()-1]);
   Serial.print(", ");
   Serial.print(charMonth[now.month()-1]);
-	Serial.print(' ');
-	Serial.print(now.date());
-	Serial.print(', ');
-	Serial.print(now.year());
-	Serial.print(' ');
-	Serial.print(now.hour());
-	Serial.print(':');
-	Serial.print(add02d(now.minute()));
-	Serial.print(':');
-	Serial.print(add02d(now.second()));
-	Serial.println(" (" + String(ts) + ")");
+  Serial.print(' ');
+  Serial.print(now.date());
+  Serial.print(", ");
+  Serial.print(now.year());
+  Serial.print(' ');
+  Serial.print(now.hour());
+  Serial.print(':');
+  Serial.print(add02d(now.minute()));
+  Serial.print(':');
+  Serial.print(add02d(now.second()));
+  Serial.println(" (" + String(ts) + ")");
 
   if (Serial.available())
   {


### PR DESCRIPTION
I was using the PCSynch.ino sketch to set the real time clock (RTC) on my Mayfly board (V0.5) and was confused by the output to the Arduino IDE's serial monitor window.  In part, the sketch is supposed to print a user-friendly version of date and time to the Mayfly's serial port every second, but the text in the Arduino serial monitor was slightly garbled.  I found errors in two Serial.print commands in the loop() block of the sketch.  This pull request only changes the formatting on the serial output in the sketch.  It doesn't mess with any of the code that sets or reads data from the RTC or synchronizes with a PC's or time server's clock.

As a side effect, it also fixes the time/date format appearing in the output for PCSynch.exe.